### PR TITLE
chore(qoi): export types.ts

### DIFF
--- a/qoi/deno.json
+++ b/qoi/deno.json
@@ -1,11 +1,12 @@
 {
   "name": "@img/qoi",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "exports": {
     ".": "./mod.ts",
     "./decode": "./decode.ts",
     "./decoder-stream": "./decoder_stream.ts",
     "./encode": "./encode.ts",
-    "./encoder-stream": "./encoder_stream.ts"
+    "./encoder-stream": "./encoder_stream.ts",
+    "./types": "./types.ts"
   }
 }


### PR DESCRIPTION
This pull request simply exports the `qoi/types.ts` file for it's own import via `jsr:@img/qoi/types`