### PR TITLE
adjust(qoi): to return a subarray

### DIFF
--- a/qoi/decode.ts
+++ b/qoi/decode.ts
@@ -73,8 +73,7 @@ export function decodeQOI(
         }) in header`,
       );
     }
-    // deno-lint-ignore no-explicit-any
-    return { header, body: new Uint8Array((output.buffer as any).transfer(o)) };
+    return { header, body: output.subarray(0, o) };
   }
   throw new RangeError("Expected more bytes from input");
 }

--- a/qoi/decoder_stream.ts
+++ b/qoi/decoder_stream.ts
@@ -97,8 +97,7 @@ export class QOIDecoderStream
           count += c;
           offset = chunk.length - i;
           if (offset) buffer.set(chunk.subarray(i));
-          // deno-lint-ignore no-explicit-any
-          yield new Uint8Array((chunk.buffer as any).transfer(o));
+          yield chunk.subarray(0, o);
           if (isEnd) {
             if (count !== width * height) {
               throw new RangeError(

--- a/qoi/encode.ts
+++ b/qoi/encode.ts
@@ -82,6 +82,5 @@ export function encodeQOI(
   }
 
   output.set([0, 0, 0, 0, 0, 0, 0, 1], o);
-  // deno-lint-ignore no-explicit-any
-  return new Uint8Array((output.buffer as any).transfer(o + 8));
+  return output.subarray(0, o + 8);
 }

--- a/qoi/encoder_stream.ts
+++ b/qoi/encoder_stream.ts
@@ -78,8 +78,7 @@ export class QOIEncoderStream extends TransformStream<Uint8Array, Uint8Array> {
         count += (i - (maxSize - originalSize - offset)) / 4;
         offset = chunk.length - i;
         if (offset) buffer.set(chunk.subarray(i));
-        // deno-lint-ignore no-explicit-any
-        controller.enqueue(new Uint8Array((chunk.buffer as any).transfer(o)));
+        controller.enqueue(chunk.subarray(0, o));
       },
       flush(controller): void {
         if (offset) {


### PR DESCRIPTION
This pull request changes the buffer being returned to a subarray of the original underlying buffer instead of reallocating the underlying buffer to reduce it's size. The reasoning being is that one might want to decode an image format to re-encode it with another format, where currently it would get `.transfer()` called on it four times, this change reduces it to two times.