### PR TITLE
fix(qoi): add missing brackets on run calculation for correct precedence

### DIFF
--- a/qoi/_encoder.ts
+++ b/qoi/_encoder.ts
@@ -38,7 +38,7 @@ export function createEncoder(isRGB: boolean): (
       } else {
         // QOI_OP_RUN
         if (run) {
-          data[o++] = 0b11 << 6 + run - 1;
+          data[o++] = (0b11 << 6) + run - 1;
           run = 0;
         }
 

--- a/qoi/deno.json
+++ b/qoi/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@img/qoi",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "exports": {
     ".": "./mod.ts",
     "./decode": "./decode.ts",


### PR DESCRIPTION
This pull request fixes a simple bug where the run calculation for values other than 62 were missing the brackets around `0b11 << 6` causing too great of a shift to the right.