### PR TITLE
fix(png): incorrect expected behaviour when decoding

### DIFF
--- a/png/deno.json
+++ b/png/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@img/png",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "exports": {
     ".": "./mod.ts",
     "./encode": "./encode/mod.ts",


### PR DESCRIPTION
This pull request fixes a simple bug related to the valid sequence that chunks can appear in when decoding.

Currently the decoding behaviour incorrectly expects that png images end with a variable number of IDAT chunks followed by an IEND chunk with no other possible chunk types in between. This is incorrect as the spec only requires no other chunk type appear between the sequence of IDAT. Other chunk types may appear after the IDAT sequence of chunks, but before the IEND chunk and this pull request changes the code to accept that.