### PR TITLE
feat(png): add AbortSignal support

### DIFF
--- a/png/decode_test.ts
+++ b/png/decode_test.ts
@@ -741,3 +741,22 @@ Deno.test("decodePNG() correctly decodes with interlace 1", async () => {
     rgba,
   );
 });
+
+Deno.test("decodePNG() aborts", async () => {
+  const controller = new AbortController();
+  controller.abort(new TypeError("POTATO"));
+
+  const buffer = await encodePNG(new Uint8Array(4), {
+    width: 1,
+    height: 1,
+    compression: 0,
+    filter: 0,
+    interlace: 0,
+  });
+
+  await assertRejects(
+    () => decodePNG(buffer, controller.signal),
+    TypeError,
+    "POTATO",
+  );
+});

--- a/png/deno.json
+++ b/png/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@img/png",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "exports": {
     ".": "./mod.ts",
     "./encode": "./encode.ts",

--- a/png/encode_test.ts
+++ b/png/encode_test.ts
@@ -474,3 +474,21 @@ Deno.test("encodePNG() correctly produces truecolor alpha images", async () => {
   }
   assertEquals(foundIHDR, true);
 });
+
+Deno.test("encodePNG() aborts", async () => {
+  const controller = new AbortController();
+  controller.abort(new TypeError("POTATO"));
+
+  await assertRejects(
+    () =>
+      encodePNG(new Uint8Array(4), {
+        width: 1,
+        height: 1,
+        compression: 0,
+        filter: 0,
+        interlace: 0,
+      }, controller.signal),
+    TypeError,
+    "POTATO",
+  );
+});


### PR DESCRIPTION
This pull request adds an optional `signal` argument to `encodePNG` and `decodePNG` that enables terminating the process part way through.