### PR TITLE
chore: switch all Uint#Array types to Uint#Array<ArrayBuffer>

### DIFF
--- a/_benchmark.ts
+++ b/_benchmark.ts
@@ -3,15 +3,17 @@ import { decodeQOI, encodeQOI } from "jsr:@img/qoi";
 
 const width = 256;
 const height = 256;
-function getData(): Promise<Uint8Array> {
-  return new Response(ReadableStream.from(function* (): Generator<Uint8Array> {
-    for (let r = 0; r < width; ++r) {
-      for (let c = 0; c < height; ++c) {
-        yield Uint8Array.from([255 - r, c, r, 255]);
+function getData(): Promise<Uint8Array<ArrayBuffer>> {
+  return new Response(
+    ReadableStream.from(function* (): Generator<Uint8Array<ArrayBuffer>> {
+      for (let r = 0; r < width; ++r) {
+        for (let c = 0; c < height; ++c) {
+          yield Uint8Array.from([255 - r, c, r, 255]);
+        }
       }
-    }
-  }()))
-    .bytes();
+    }()),
+  )
+    .bytes() as Promise<Uint8Array<ArrayBuffer>>;
 }
 
 const RAW_INPUT = await getData();

--- a/internal/apng_png/_common_filter.ts
+++ b/internal/apng_png/_common_filter.ts
@@ -1,6 +1,6 @@
 export const filterTypes = [
   function type0(
-    _lines: Uint8Array[],
+    _lines: Uint8Array<ArrayBuffer>[],
     _x: number,
     _y: number,
     _pSize: number,
@@ -8,7 +8,7 @@ export const filterTypes = [
     return 0;
   },
   function type1(
-    lines: Uint8Array[],
+    lines: Uint8Array<ArrayBuffer>[],
     x: number,
     y: number,
     pSize: number,
@@ -16,7 +16,7 @@ export const filterTypes = [
     return lines[y][x - pSize] ?? 0;
   },
   function type2(
-    lines: Uint8Array[],
+    lines: Uint8Array<ArrayBuffer>[],
     x: number,
     y: number,
     _pSize: number,
@@ -24,7 +24,7 @@ export const filterTypes = [
     return y === 0 ? 0 : lines[y - 1][x];
   },
   function type3(
-    lines: Uint8Array[],
+    lines: Uint8Array<ArrayBuffer>[],
     x: number,
     y: number,
     pSize: number,
@@ -35,7 +35,7 @@ export const filterTypes = [
         ) / 2 | 0;
   },
   function type4(
-    lines: Uint8Array[],
+    lines: Uint8Array<ArrayBuffer>[],
     x: number,
     y: number,
     pSize: number,

--- a/internal/apng_png/crc.ts
+++ b/internal/apng_png/crc.ts
@@ -1,4 +1,4 @@
-const CRC = function (): Uint32Array {
+const CRC = function (): Uint32Array<ArrayBuffer> {
   const array = new Uint32Array(256);
   for (let i = 0; i < 256; ++i) {
     let x = i;
@@ -10,7 +10,9 @@ const CRC = function (): Uint32Array {
   return array;
 }();
 
-export function calcCRC(buffer: Uint8Array | Uint8ClampedArray): number {
+export function calcCRC(
+  buffer: Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer>,
+): number {
   let crc = 0xFFFFFFFF;
   for (let i = 0; i < buffer.length; ++i) {
     crc = CRC[(crc ^ buffer[i]) & 0xFF] ^ (crc >>> 8);

--- a/internal/apng_png/crc_test.ts
+++ b/internal/apng_png/crc_test.ts
@@ -6,5 +6,8 @@ Deno.test("calcCRC() with empty buffer", () => {
 });
 
 Deno.test('calcCRC() with "Hello World"', () => {
-  assertEquals(calcCRC(new TextEncoder().encode("Hello World")), 0x4a17b156);
+  assertEquals(
+    calcCRC(new TextEncoder().encode("Hello World") as Uint8Array<ArrayBuffer>),
+    0x4a17b156,
+  );
 });

--- a/internal/apng_png/decode/_filter.ts
+++ b/internal/apng_png/decode/_filter.ts
@@ -1,10 +1,10 @@
 import { filterTypes } from "../_common_filter.ts";
 
 export function filter(
-  mid: Uint8Array,
-  images: Uint8Array[][],
+  mid: Uint8Array<ArrayBuffer>,
+  images: Uint8Array<ArrayBuffer>[][],
   pSize: number,
-): Uint8Array {
+): Uint8Array<ArrayBuffer> {
   for (const lines of images) {
     for (let y = 0; y < lines.length; ++y) {
       const index = lines[y][0];

--- a/internal/apng_png/decode/_from.ts
+++ b/internal/apng_png/decode/_from.ts
@@ -1,5 +1,5 @@
 export function makePixelTransparent(
-  output: Uint8Array,
+  output: Uint8Array<ArrayBuffer>,
   r: number,
   g: number,
   b: number,
@@ -11,7 +11,10 @@ export function makePixelTransparent(
   }
 }
 
-export function fromGrayscale(output: Uint8Array, i: number): void {
+export function fromGrayscale(
+  output: Uint8Array<ArrayBuffer>,
+  i: number,
+): void {
   let o = 0;
   for (; i < output.length; ++i) {
     output[o++] = output[i];
@@ -21,7 +24,10 @@ export function fromGrayscale(output: Uint8Array, i: number): void {
   }
 }
 
-export function fromGrayscaleAlpha(output: Uint8Array, i: number): void {
+export function fromGrayscaleAlpha(
+  output: Uint8Array<ArrayBuffer>,
+  i: number,
+): void {
   let o = 0;
   for (; i < output.length; i += 2) {
     output[o++] = output[i];
@@ -31,7 +37,10 @@ export function fromGrayscaleAlpha(output: Uint8Array, i: number): void {
   }
 }
 
-export function fromTruecolor(output: Uint8Array, i: number): void {
+export function fromTruecolor(
+  output: Uint8Array<ArrayBuffer>,
+  i: number,
+): void {
   let o = 0;
   for (; i < output.length; i += 3) {
     output[o++] = output[i];
@@ -42,9 +51,9 @@ export function fromTruecolor(output: Uint8Array, i: number): void {
 }
 
 export function fromIndex(
-  output: Uint8Array,
+  output: Uint8Array<ArrayBuffer>,
   i: number,
-  palette: Uint32Array,
+  palette: Uint32Array<ArrayBuffer>,
 ): void {
   let o = 0;
   for (; i < output.length; ++i) {

--- a/internal/apng_png/decode/_passExtraction.ts
+++ b/internal/apng_png/decode/_passExtraction.ts
@@ -3,8 +3,8 @@ import type { PNGOptions } from "../types.ts";
 export { images };
 
 export function passExtraction(
-  output: Uint8Array,
-  mid: Uint8Array,
+  output: Uint8Array<ArrayBuffer>,
+  mid: Uint8Array<ArrayBuffer>,
   options: PNGOptions,
   pSize: number,
   sizes: [number, number][],

--- a/internal/apng_png/decode/_scanlines.ts
+++ b/internal/apng_png/decode/_scanlines.ts
@@ -1,9 +1,9 @@
 export function scanlines(
-  mid: Uint8Array,
+  mid: Uint8Array<ArrayBuffer>,
   pSize: number,
   sizes: [number, number][],
-): Uint8Array[][] {
-  const images: Uint8Array[][] = new Array(sizes.length)
+): Uint8Array<ArrayBuffer>[][] {
+  const images: Uint8Array<ArrayBuffer>[][] = new Array(sizes.length)
     .fill(0)
     .map(() => []);
   let i = 0;

--- a/internal/apng_png/encode/_filter.ts
+++ b/internal/apng_png/encode/_filter.ts
@@ -1,10 +1,10 @@
 import { filterTypes } from "../_common_filter.ts";
 
 export function filter(
-  output: Uint8Array,
+  output: Uint8Array<ArrayBuffer>,
   colorType: number,
   pSize: number,
-  images: Uint8Array[][],
+  images: Uint8Array<ArrayBuffer>[][],
 ): number {
   images = images.filter((x) => x.filter((x) => x.length).length);
   const o = output.length -

--- a/internal/apng_png/encode/_passExtraction.ts
+++ b/internal/apng_png/encode/_passExtraction.ts
@@ -2,7 +2,7 @@ import { images, moveTo } from "../_common_pass.ts";
 import type { PNGOptions } from "../types.ts";
 
 export function passExtraction(
-  input: Uint8Array,
+  input: Uint8Array<ArrayBuffer>,
   pSize: number,
   options: PNGOptions,
 ): [number, number][] {

--- a/internal/apng_png/encode/_scanlines.ts
+++ b/internal/apng_png/encode/_scanlines.ts
@@ -1,9 +1,9 @@
 export function scanlines(
-  input: Uint8Array,
+  input: Uint8Array<ArrayBuffer>,
   pSize: number,
   images: [number, number][],
-): Uint8Array[][] {
-  const output: Uint8Array[][] = new Array(images.length)
+): Uint8Array<ArrayBuffer>[][] {
+  const output: Uint8Array<ArrayBuffer>[][] = new Array(images.length)
     .fill(0)
     .map(() => []);
   let i = 0;

--- a/internal/apng_png/encode/_to.ts
+++ b/internal/apng_png/encode/_to.ts
@@ -1,5 +1,5 @@
 export function guaranteeInvisiblePixel(
-  input: Uint8Array | Uint8ClampedArray,
+  input: Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer>,
   colors: Map<number, number>,
   forGrayscale: boolean,
 ): number | undefined {
@@ -46,7 +46,7 @@ export function guaranteeInvisiblePixel(
 }
 
 function replaceTransparentPixels(
-  input: Uint8Array | Uint8ClampedArray,
+  input: Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer>,
   r: number,
   g: number,
   b: number,
@@ -61,15 +61,15 @@ function replaceTransparentPixels(
 }
 
 export function toGrayscale(
-  input: Uint8Array | Uint8ClampedArray,
-): Uint8Array | Uint8ClampedArray {
+  input: Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer>,
+): Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer> {
   for (let i = 4; i < input.length; i += 4) input[i / 4] = input[i];
   return input.subarray(0, input.length / 4);
 }
 
 export function toGrayscaleAlpha(
-  input: Uint8Array | Uint8ClampedArray,
-): Uint8Array | Uint8ClampedArray {
+  input: Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer>,
+): Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer> {
   input[1] = input[3];
   for (let i = 4; i < input.length; i += 4) {
     input[i / 2] = input[i];
@@ -79,8 +79,8 @@ export function toGrayscaleAlpha(
 }
 
 export function toTruecolor(
-  input: Uint8Array | Uint8ClampedArray,
-): Uint8Array | Uint8ClampedArray {
+  input: Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer>,
+): Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer> {
   for (let i = 4; i < input.length; i += 4) {
     input[i / 4 * 3] = input[i];
     input[i / 4 * 3 + 1] = input[i + 1];
@@ -90,9 +90,9 @@ export function toTruecolor(
 }
 
 export function toIndex(
-  input: Uint8Array | Uint8ClampedArray,
-  palette: Uint32Array,
-): Uint8Array | Uint8ClampedArray {
+  input: Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer>,
+  palette: Uint32Array<ArrayBuffer>,
+): Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer> {
   const view = new DataView(input.buffer, input.byteOffset, input.byteLength);
   for (let i = 0; i < input.length; i += 4) {
     input[i / 4] = palette.indexOf(view.getUint32(i));

--- a/internal/deno.json
+++ b/internal/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@img/internal",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "exports": {
     "./apng-png/crc": "./apng_png/crc.ts",
     "./apng-png/types": "./apng_png/types.ts",

--- a/localhost/static/ts/main.ts
+++ b/localhost/static/ts/main.ts
@@ -41,15 +41,15 @@ document.querySelector<HTMLFormElement>("form")
 
 async function decode(
   file: File,
-): Promise<[Uint8Array, number, number]> {
+): Promise<[Uint8Array<ArrayBuffer>, number, number]> {
   switch (file.type ?? extname(file.name)) {
     case ".png":
     case "image/png": {
-      const x = await decodePNG(await file.bytes());
+      const x = await decodePNG(await file.bytes() as Uint8Array<ArrayBuffer>);
       return [x.body, x.header.width, x.header.height];
     }
     default: {
-      const x = decodeQOI(await file.bytes());
+      const x = decodeQOI(await file.bytes() as Uint8Array<ArrayBuffer>);
       return [x.body, x.header.width, x.header.height];
     }
   }
@@ -57,10 +57,10 @@ async function decode(
 
 async function encode(
   inputTag: HTMLInputElement,
-  input: Uint8Array,
+  input: Uint8Array<ArrayBuffer>,
   width: number,
   height: number,
-): Promise<Uint8Array> {
+): Promise<Uint8Array<ArrayBuffer>> {
   switch (inputTag.value) {
     case "PNG":
       return await encodePNG(input, {

--- a/png/decode_test.ts
+++ b/png/decode_test.ts
@@ -6,13 +6,13 @@ import { calcCRC } from "@img/internal/apng-png/crc";
 
 interface Chunk {
   length: number;
-  type: Uint8Array;
-  data: Uint8Array;
+  type: Uint8Array<ArrayBuffer>;
+  data: Uint8Array<ArrayBuffer>;
   crc: number;
 }
 
 function getChunk(
-  buffer: Uint8Array,
+  buffer: Uint8Array<ArrayBuffer>,
   view: DataView,
   offset: number,
 ): Chunk {

--- a/png/deno.json
+++ b/png/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@img/png",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "exports": {
     ".": "./mod.ts",
     "./encode": "./encode.ts",

--- a/png/mod.ts
+++ b/png/mod.ts
@@ -19,7 +19,7 @@
  *       yield Uint8Array.from([255 - r, c, r, 255]);
  *     }
  *   }
- * }())).bytes();
+ * }())).bytes() as Uint8Array<ArrayBuffer>;
  *
  * await Deno.writeFile(".output/mod.png", await encodePNG(rawData, {
  *   width: 256,

--- a/qoi/_common.ts
+++ b/qoi/_common.ts
@@ -1,4 +1,7 @@
-export function calcIndex(pixel: Uint8Array, isRGB: boolean): number {
+export function calcIndex(
+  pixel: Uint8Array<ArrayBuffer>,
+  isRGB: boolean,
+): number {
   return (
     pixel[0] * 3 +
     pixel[1] * 5 +

--- a/qoi/_decoder.ts
+++ b/qoi/_decoder.ts
@@ -1,16 +1,16 @@
 import { calcIndex } from "./_common.ts";
 
 export function createDecoder(): (
-  input: Uint8Array,
+  input: Uint8Array<ArrayBuffer>,
   i: number,
   o: number,
 ) => { i: number; o: number; c: number; isEnd: boolean } {
   const previousPixel = new Uint8Array([0, 0, 0, 255]);
-  const seenPixels: Uint8Array[] = new Array(64)
+  const seenPixels: Uint8Array<ArrayBuffer>[] = new Array(64)
     .fill(0)
     .map((_) => new Uint8Array([0, 0, 0, 0]));
   return function (
-    data: Uint8Array,
+    data: Uint8Array<ArrayBuffer>,
     i: number,
     o: number,
   ): { i: number; o: number; c: number; isEnd: boolean } {

--- a/qoi/_encoder.ts
+++ b/qoi/_encoder.ts
@@ -1,8 +1,8 @@
 import { calcIndex } from "./_common.ts";
 
 export function isEqual(
-  previousPixel: Uint8Array,
-  currentPixel: Uint8Array,
+  previousPixel: Uint8Array<ArrayBuffer>,
+  currentPixel: Uint8Array<ArrayBuffer>,
   isRGB: boolean,
 ): boolean {
   for (let i = 0; i < (isRGB ? 3 : 4); ++i) {
@@ -12,17 +12,17 @@ export function isEqual(
 }
 
 export function createEncoder(isRGB: boolean): (
-  data: Uint8Array,
+  data: Uint8Array<ArrayBuffer>,
   i: number,
   o: number,
 ) => { i: number; o: number } {
   let run = 0;
   const previousPixel = new Uint8Array([0, 0, 0, 255]);
-  const seenPixels: Uint8Array[] = new Array(64)
+  const seenPixels: Uint8Array<ArrayBuffer>[] = new Array(64)
     .fill(0)
     .map((_) => new Uint8Array([0, 0, 0, 0]));
   return function (
-    data: Uint8Array,
+    data: Uint8Array<ArrayBuffer>,
     i: number,
     o: number,
   ): { i: number; o: number } {

--- a/qoi/decode.ts
+++ b/qoi/decode.ts
@@ -15,7 +15,7 @@ import type { QOIOptions } from "./types.ts";
  *         yield new Uint8Array([255 - r, c, r, 255]);
  *       }
  *     }
- *   }())).bytes(),
+ *   }())).bytes() as Uint8Array<ArrayBuffer>,
  *   { width: 256, height: 256, channels: "rgb", colorspace: 0 },
  * );
  *
@@ -28,8 +28,8 @@ import type { QOIOptions } from "./types.ts";
  * @module
  */
 export function decodeQOI(
-  input: Uint8Array | Uint8ClampedArray,
-): { header: QOIOptions; body: Uint8Array } {
+  input: Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer>,
+): { header: QOIOptions; body: Uint8Array<ArrayBuffer> } {
   if (input.length < 14 + 8) {
     throw new RangeError("QOI input is too short to be valid");
   }

--- a/qoi/decoder_stream.ts
+++ b/qoi/decoder_stream.ts
@@ -18,17 +18,19 @@ import { createDecoder } from "./_decoder.ts";
  * @module
  */
 export class QOIDecoderStream
-  implements TransformStream<Uint8Array, Uint8Array> {
-  #readable: ReadableStream<Uint8Array>;
-  #writable: WritableStream<Uint8Array>;
+  implements TransformStream<Uint8Array<ArrayBuffer>, Uint8Array<ArrayBuffer>> {
+  #readable: ReadableStream<Uint8Array<ArrayBuffer>>;
+  #writable: WritableStream<Uint8Array<ArrayBuffer>>;
   constructor(cb: (header: QOIOptions) => unknown = () => {}) {
     const { readable, writable } = new TransformStream<
-      Uint8Array,
-      Uint8Array
+      Uint8Array<ArrayBuffer>,
+      Uint8Array<ArrayBuffer>
     >();
     this.#readable = ReadableStream.from(
-      async function* (): AsyncGenerator<Uint8Array> {
-        const byteStream = toByteStream(readable);
+      async function* (): AsyncGenerator<Uint8Array<ArrayBuffer>> {
+        const byteStream = toByteStream(readable) as ReadableStream<
+          Uint8Array<ArrayBuffer>
+        >;
         const { width, height, isRGB } = await async function (): Promise<
           { width: number; height: number; isRGB: boolean }
         > {
@@ -115,11 +117,11 @@ export class QOIDecoderStream
     this.#writable = writable;
   }
 
-  get readable(): ReadableStream<Uint8Array> {
+  get readable(): ReadableStream<Uint8Array<ArrayBuffer>> {
     return this.#readable;
   }
 
-  get writable(): WritableStream<Uint8Array> {
+  get writable(): WritableStream<Uint8Array<ArrayBuffer>> {
     return this.#writable;
   }
 }

--- a/qoi/deno.json
+++ b/qoi/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@img/qoi",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "exports": {
     ".": "./mod.ts",
     "./decode": "./decode.ts",

--- a/qoi/encode.ts
+++ b/qoi/encode.ts
@@ -18,7 +18,7 @@ import type { QOIOptions } from "./types.ts";
  *       yield Uint8Array.from([255 - r, c, r, 255]);
  *     }
  *   }
- * }())).bytes();
+ * }())).bytes() as Uint8Array<ArrayBuffer>;
  *
  * await Deno.writeFile(".output/image.qoi", encodeQOI(rawData, {
  *   width: 256,
@@ -34,9 +34,9 @@ import type { QOIOptions } from "./types.ts";
  * @module
  */
 export function encodeQOI(
-  input: Uint8Array | Uint8ClampedArray,
+  input: Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer>,
   options: QOIOptions,
-): Uint8Array {
+): Uint8Array<ArrayBuffer> {
   if (options.width < 0 || Number.isNaN(options.width)) {
     throw new RangeError("Width cannot be a negative number or NaN");
   }

--- a/qoi/encoder_stream.ts
+++ b/qoi/encoder_stream.ts
@@ -33,7 +33,8 @@ import type { QOIOptions } from "./types.ts";
  *
  * @module
  */
-export class QOIEncoderStream extends TransformStream<Uint8Array, Uint8Array> {
+export class QOIEncoderStream
+  extends TransformStream<Uint8Array<ArrayBuffer>, Uint8Array<ArrayBuffer>> {
   constructor(options: QOIOptions) {
     if (options.width < 0 || Number.isNaN(options.width)) {
       throw new RangeError("Width cannot be a negative number or NaN");

--- a/qoi/mod.ts
+++ b/qoi/mod.ts
@@ -21,7 +21,7 @@
  *       yield Uint8Array.from([255 - r, c, r, 255]);
  *     }
  *   }
- * }())).bytes();
+ * }())).bytes() as Uint8Array<ArrayBuffer>;
  *
  * await Deno.writeFile(".output/image.qoi", encodeQOI(rawData, {
  *   width: 256,


### PR DESCRIPTION
This pull request simply makes the typings more explicit. From `Uint8Array` to `Uint8Array<ArrayBuffer>` because `Uint8Array<SharedArrayBuffer>` is invalid for many instances in this module, but the typings previously allowed it. It also previously suggested that the underlying buffer returned from these functions might not be an ArrayBuffer, which was always false.